### PR TITLE
Make "ROM Name" textbox more obvious.

### DIFF
--- a/src/Components/AddNewRomModal.js
+++ b/src/Components/AddNewRomModal.js
@@ -195,7 +195,7 @@ class AddNewRomModal extends React.Component
                         <Form.Group as={Row}>
                             <Form.Label column sm="2">ROM Name:</Form.Label>
                             <Col sm="10">
-                            <Form.Control plaintext maxLength={16} value={this.state.romInfo.name} onChange={(e) => this.setState({romInfo: {name: e.target.value, banks: this.state.romInfo.banks, speedchangeBank: this.state.romInfo.speedchangeBank}})} />
+                            <Form.Control type="text" maxLength={16} value={this.state.romInfo.name} onChange={(e) => this.setState({romInfo: {name: e.target.value, banks: this.state.romInfo.banks, speedchangeBank: this.state.romInfo.speedchangeBank}})} />
                             </Col>
                         </Form.Group>
                         <Form.Group as={Row}>


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/23ca57da-b3d1-42bc-ad5f-899e554a53bc)


Makes the "ROM Name" textbox more obvious that it can be edited. 